### PR TITLE
Fix missing super call in onStateReplaced

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.jvmargs=-Xmx8G
 
 
 # Mod Properties
-	mod_version = 1.0.4
+	mod_version = 1.0.5
 	maven_group = net.jptrzy
 	archives_base_name = infusion-table-mod
 

--- a/src/main/java/net/jptrzy/infusion/table/blocks/InfusionTableBlock.java
+++ b/src/main/java/net/jptrzy/infusion/table/blocks/InfusionTableBlock.java
@@ -45,6 +45,7 @@ public class InfusionTableBlock extends Block implements BlockEntityProvider {
     public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
         if (!state.isOf(newState.getBlock())) {
             ((InfusionTableEntity) world.getBlockEntity(pos)).onBreak(state, world, pos, null);
+	    super.onStateReplaced(state, world, pos, newState, moved);
         }
     }
 

--- a/src/main/resources/assets/infusion_table/lang/pl_pl.json
+++ b/src/main/resources/assets/infusion_table/lang/pl_pl.json
@@ -1,0 +1,3 @@
+{
+  "block.infusion_table.infusion_table": "Stół Transmutacyjny"
+}

--- a/src/main/resources/assets/infusion_table/lang/ru_ru.json
+++ b/src/main/resources/assets/infusion_table/lang/ru_ru.json
@@ -1,0 +1,3 @@
+{
+  "block.infusion_table.infusion_table": "Стол Трансфигурации"
+}


### PR DESCRIPTION
If this call is missing, the block entity will not be removed upon the block being broken. This can then later cause ugly issues with other mods and is just in general not good