### PR TITLE
update versions for 1.19.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,16 +2,16 @@
 org.gradle.jvmargs=-Xmx8G
 
 # Fabric Properties
-	minecraft_version=1.19
-	yarn_mappings=1.19+build.1
-	loader_version=0.14.7
+	minecraft_version=1.19.2
+	yarn_mappings=1.19.2+build.28
+	loader_version=0.14.17
 
 
 
 # Mod Properties
-	mod_version = 1.1.0
+	mod_version = 1.1.1
 	maven_group = net.jptrzy
 	archives_base_name = infusion-table-mod
 
 # Dependencies
-	fabric_version=0.55.3+1.19
+	fabric_version=0.76.0+1.19.2

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,9 +28,9 @@
   },
   "mixins": [],
   "depends": {
-    "fabricloader": ">=0.11.3",
+    "fabricloader": ">=0.14.17",
     "fabric": "*",
-    "minecraft": "1.19.x",
+    "minecraft": "1.19.2",
     "java": ">=17"
   },
   "suggests": {}


### PR DESCRIPTION
This change may be unnecessary, but I went ahead and made it because I saw that the mod doesn't have a download option for 1.19.2.